### PR TITLE
Connection validation with shared key

### DIFF
--- a/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorDiscovery.cs
+++ b/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorDiscovery.cs
@@ -11,7 +11,7 @@ namespace Mirror.LiteNetLib4Mirror
 		public UnityEventIpEndpointString onDiscoveryResponse;
 		public ushort[] ports = {7777};
 		private static readonly NetDataWriter DataWriter = new NetDataWriter();
-        public static string DiscoveryKey { get; protected set; }
+		public static string DiscoveryKey { get; protected set; }
 		public static LiteNetLib4MirrorDiscovery Singleton { get; protected set; }
 		private static string _lastDiscoveryMessage;
 
@@ -36,14 +36,14 @@ namespace Mirror.LiteNetLib4Mirror
 			return true;
 		}
 		
-        /// <summary>
+		/// <summary>
 		/// Override this in your code to set the key used for discovery requests.
-        /// </summary>
-        protected virtual void SetDiscoveryKey()
-        {
-            DiscoveryKey = LiteNetLib4MirrorUtils.ApplicationName;
-        }
-        #endregion
+		/// </summary>
+		protected virtual void SetDiscoveryKey()
+		{
+			DiscoveryKey = LiteNetLib4MirrorUtils.ApplicationName;
+		}
+		#endregion
 
 		public static void InitializeFinder()
 		{
@@ -84,8 +84,8 @@ namespace Mirror.LiteNetLib4Mirror
 			}
 		}
 
-        private static void OnDiscoveryResponse(IPEndPoint remoteendpoint, NetPacketReader reader, UnconnectedMessageType messagetype)
-        {
+		private static void OnDiscoveryResponse(IPEndPoint remoteendpoint, NetPacketReader reader, UnconnectedMessageType messagetype)
+		{
 			if (messagetype == UnconnectedMessageType.BasicMessage && reader.TryGetString(out string key) && key == DiscoveryKey)
 			{
 				Singleton.onDiscoveryResponse.Invoke(remoteendpoint, LiteNetLib4MirrorUtils.FromBase64(reader.GetString()));
@@ -93,8 +93,8 @@ namespace Mirror.LiteNetLib4Mirror
 			reader.Recycle();
 		}
 
-        internal static void OnDiscoveryRequest(IPEndPoint remoteendpoint, NetPacketReader reader, UnconnectedMessageType messagetype)
-        {
+		internal static void OnDiscoveryRequest(IPEndPoint remoteendpoint, NetPacketReader reader, UnconnectedMessageType messagetype)
+		{
 			if (messagetype == UnconnectedMessageType.Broadcast && reader.TryGetString(out string key) && key == DiscoveryKey && Singleton.ProcessDiscoveryRequest(remoteendpoint, LiteNetLib4MirrorUtils.FromBase64(reader.GetString()), out string response))
 			{
 				LiteNetLib4MirrorCore.Host.SendUnconnectedMessage(LiteNetLib4MirrorUtils.ReusePutDiscovery(DataWriter, response, ref _lastDiscoveryMessage), remoteendpoint);

--- a/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorDiscovery.cs
+++ b/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorDiscovery.cs
@@ -73,7 +73,7 @@ namespace Mirror.LiteNetLib4Mirror
 
 		private static void OnDiscoveryResponse(IPEndPoint remoteendpoint, NetPacketReader reader, UnconnectedMessageType messagetype)
 		{
-			if (messagetype == UnconnectedMessageType.BasicMessage && reader.TryGetString(out string application) && application == Application.productName)
+			if (messagetype == UnconnectedMessageType.BasicMessage && reader.TryGetString(out string key) && key == LiteNetLib4MirrorUtils.SharedKey)
 			{
 				Singleton.onDiscoveryResponse.Invoke(remoteendpoint, LiteNetLib4MirrorUtils.FromBase64(reader.GetString()));
 			}
@@ -82,7 +82,7 @@ namespace Mirror.LiteNetLib4Mirror
 
 		internal static void OnDiscoveryRequest(IPEndPoint remoteendpoint, NetPacketReader reader, UnconnectedMessageType messagetype)
 		{
-			if (messagetype == UnconnectedMessageType.Broadcast && reader.TryGetString(out string application) && application == Application.productName && Singleton.ProcessDiscoveryRequest(remoteendpoint, LiteNetLib4MirrorUtils.FromBase64(reader.GetString()), out string response))
+			if (messagetype == UnconnectedMessageType.Broadcast && reader.TryGetString(out string key) && key == LiteNetLib4MirrorUtils.SharedKey && Singleton.ProcessDiscoveryRequest(remoteendpoint, LiteNetLib4MirrorUtils.FromBase64(reader.GetString()), out string response))
 			{
 				LiteNetLib4MirrorCore.Host.SendUnconnectedMessage(LiteNetLib4MirrorUtils.ReusePutDiscovery(DataWriter, response, ref _lastDiscoveryMessage), remoteendpoint);
 			}

--- a/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorDiscovery.cs
+++ b/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorDiscovery.cs
@@ -11,9 +11,11 @@ namespace Mirror.LiteNetLib4Mirror
 		public UnityEventIpEndpointString onDiscoveryResponse;
 		public ushort[] ports = {7777};
 		private static readonly NetDataWriter DataWriter = new NetDataWriter();
+        public static string DiscoveryKey { get; protected set; }
 		public static LiteNetLib4MirrorDiscovery Singleton { get; protected set; }
 		private static string _lastDiscoveryMessage;
 
+		#region Overridable methods
 		protected virtual void Awake()
 		{
 			if (Singleton == null)
@@ -21,6 +23,8 @@ namespace Mirror.LiteNetLib4Mirror
 				GetComponent<LiteNetLib4MirrorTransport>().InitializeTransport();
 				Singleton = this;
 			}
+
+			SetDiscoveryKey();
 		}
 
 		/// <summary>
@@ -31,6 +35,15 @@ namespace Mirror.LiteNetLib4Mirror
 			response = "LiteNetLib4Mirror Discovery accepted";
 			return true;
 		}
+		
+        /// <summary>
+		/// Override this in your code to set the key used for discovery requests.
+        /// </summary>
+        protected virtual void SetDiscoveryKey()
+        {
+            DiscoveryKey = LiteNetLib4MirrorUtils.ApplicationName;
+        }
+        #endregion
 
 		public static void InitializeFinder()
 		{
@@ -71,18 +84,18 @@ namespace Mirror.LiteNetLib4Mirror
 			}
 		}
 
-		private static void OnDiscoveryResponse(IPEndPoint remoteendpoint, NetPacketReader reader, UnconnectedMessageType messagetype)
-		{
-			if (messagetype == UnconnectedMessageType.BasicMessage && reader.TryGetString(out string key) && key == LiteNetLib4MirrorUtils.SharedKey)
+        private static void OnDiscoveryResponse(IPEndPoint remoteendpoint, NetPacketReader reader, UnconnectedMessageType messagetype)
+        {
+			if (messagetype == UnconnectedMessageType.BasicMessage && reader.TryGetString(out string key) && key == DiscoveryKey)
 			{
 				Singleton.onDiscoveryResponse.Invoke(remoteendpoint, LiteNetLib4MirrorUtils.FromBase64(reader.GetString()));
 			}
 			reader.Recycle();
 		}
 
-		internal static void OnDiscoveryRequest(IPEndPoint remoteendpoint, NetPacketReader reader, UnconnectedMessageType messagetype)
-		{
-			if (messagetype == UnconnectedMessageType.Broadcast && reader.TryGetString(out string key) && key == LiteNetLib4MirrorUtils.SharedKey && Singleton.ProcessDiscoveryRequest(remoteendpoint, LiteNetLib4MirrorUtils.FromBase64(reader.GetString()), out string response))
+        internal static void OnDiscoveryRequest(IPEndPoint remoteendpoint, NetPacketReader reader, UnconnectedMessageType messagetype)
+        {
+			if (messagetype == UnconnectedMessageType.Broadcast && reader.TryGetString(out string key) && key == DiscoveryKey && Singleton.ProcessDiscoveryRequest(remoteendpoint, LiteNetLib4MirrorUtils.FromBase64(reader.GetString()), out string response))
 			{
 				LiteNetLib4MirrorCore.Host.SendUnconnectedMessage(LiteNetLib4MirrorUtils.ReusePutDiscovery(DataWriter, response, ref _lastDiscoveryMessage), remoteendpoint);
 			}

--- a/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorTransport.cs
+++ b/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorTransport.cs
@@ -151,7 +151,7 @@ namespace Mirror.LiteNetLib4Mirror
 
 		private static string GetConnectKey()
 		{
-			return LiteNetLib4MirrorUtils.ToBase64(Application.productName + Application.companyName + Application.unityVersion + LiteNetLib4MirrorCore.TransportVersion + Singleton.authCode);
+			return LiteNetLib4MirrorUtils.ToBase64(LiteNetLib4MirrorUtils.SharedKey + Application.unityVersion + LiteNetLib4MirrorCore.TransportVersion + Singleton.authCode);
 		}
 
 		#region Unity Functions

--- a/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorTransport.cs
+++ b/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorTransport.cs
@@ -114,12 +114,14 @@ namespace Mirror.LiteNetLib4Mirror
 		public UnityEventError onClientSocketError;
 		public UnityEventIntError onServerSocketError;
 
+        protected internal static string ConnectKey { get; set; }
+
 		internal static bool Polling;
 		private static readonly NetDataWriter ConnectWriter = new NetDataWriter();
 		#region Overridable methods
 		protected internal virtual void GetConnectData(NetDataWriter writer)
 		{
-			writer.Put(GetConnectKey());
+			writer.Put(ConnectKey);
 		}
 
 		protected internal virtual void ProcessConnectionRequest(ConnectionRequest request)
@@ -134,6 +136,14 @@ namespace Mirror.LiteNetLib4Mirror
 			}
 		}
 
+        /// <summary>
+        /// Override this in your code to set the key used for connection requests.
+        /// </summary>
+        protected internal virtual void SetConnectKey()
+        {
+            ConnectKey = LiteNetLib4MirrorUtils.ToBase64(Application.productName + Application.companyName + Application.unityVersion + LiteNetLib4MirrorCore.TransportVersion + Singleton.authCode);
+        }
+
 		protected internal virtual void OnConncetionRefused(DisconnectInfo disconnectinfo)
 		{
 
@@ -147,11 +157,8 @@ namespace Mirror.LiteNetLib4Mirror
 				Singleton = this;
 				LiteNetLib4MirrorCore.State = LiteNetLib4MirrorCore.States.Idle;
 			}
-		}
 
-		private static string GetConnectKey()
-		{
-			return LiteNetLib4MirrorUtils.ToBase64(LiteNetLib4MirrorUtils.SharedKey + Application.unityVersion + LiteNetLib4MirrorCore.TransportVersion + Singleton.authCode);
+            SetConnectKey();
 		}
 
 		#region Unity Functions
@@ -219,7 +226,7 @@ namespace Mirror.LiteNetLib4Mirror
 
 		public override void ServerStart()
 		{
-			LiteNetLib4MirrorServer.StartServer(GetConnectKey());
+			LiteNetLib4MirrorServer.StartServer(ConnectKey);
 		}
 
 		public override bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> data)

--- a/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorTransport.cs
+++ b/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorTransport.cs
@@ -114,7 +114,7 @@ namespace Mirror.LiteNetLib4Mirror
 		public UnityEventError onClientSocketError;
 		public UnityEventIntError onServerSocketError;
 
-        protected internal static string ConnectKey { get; set; }
+		protected internal static string ConnectKey { get; set; }
 
 		internal static bool Polling;
 		private static readonly NetDataWriter ConnectWriter = new NetDataWriter();
@@ -136,13 +136,13 @@ namespace Mirror.LiteNetLib4Mirror
 			}
 		}
 
-        /// <summary>
-        /// Override this in your code to set the key used for connection requests.
-        /// </summary>
-        protected internal virtual void SetConnectKey()
-        {
-            ConnectKey = LiteNetLib4MirrorUtils.ToBase64(Application.productName + Application.companyName + Application.unityVersion + LiteNetLib4MirrorCore.TransportVersion + Singleton.authCode);
-        }
+		/// <summary>
+		/// Override this in your code to set the key used for connection requests.
+		/// </summary>
+		protected internal virtual void SetConnectKey()
+		{
+			ConnectKey = LiteNetLib4MirrorUtils.ToBase64(Application.productName + Application.companyName + Application.unityVersion + LiteNetLib4MirrorCore.TransportVersion + Singleton.authCode);
+		}
 
 		protected internal virtual void OnConncetionRefused(DisconnectInfo disconnectinfo)
 		{
@@ -158,7 +158,7 @@ namespace Mirror.LiteNetLib4Mirror
 				LiteNetLib4MirrorCore.State = LiteNetLib4MirrorCore.States.Idle;
 			}
 
-            SetConnectKey();
+			SetConnectKey();
 		}
 
 		#region Unity Functions

--- a/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorUtils.cs
+++ b/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorUtils.cs
@@ -19,13 +19,13 @@ namespace Mirror.LiteNetLib4Mirror
 	public static class LiteNetLib4MirrorUtils
 	{
 		internal static ushort LastForwardedPort;
-		internal static readonly string ApplicationName;
+		public static string SharedKey { get; set; }
 		public static bool UpnpFailed { get; private set; }
 		public static IPAddress ExternalIp { get; private set; }
 
 		static LiteNetLib4MirrorUtils()
 		{
-			ApplicationName = Application.productName;
+			SharedKey = Application.productName + Application.companyName;
 		}
 
 		public static string ToBase64(string text)
@@ -52,11 +52,11 @@ namespace Mirror.LiteNetLib4Mirror
 
 		public static NetDataWriter ReusePutDiscovery(NetDataWriter writer, string text, ref string lastText)
 		{
-			if (ApplicationName + text != lastText)
+			if (SharedKey + text != lastText)
 			{
-				lastText = ApplicationName + text;
+				lastText = SharedKey + text;
 				writer.Reset();
-				writer.Put(ApplicationName);
+				writer.Put(SharedKey);
 				writer.Put(ToBase64(text));
 			}
 
@@ -155,7 +155,7 @@ namespace Mirror.LiteNetLib4Mirror
 				}
 
 				ExternalIp = await device.GetExternalIPAsync();
-				await device.CreatePortMapAsync(new Mapping(networkProtocolType, IPAddress.None, port, port, 0, ApplicationName)).ConfigureAwait(false);
+				await device.CreatePortMapAsync(new Mapping(networkProtocolType, IPAddress.None, port, port, 0, Application.productName)).ConfigureAwait(false);
 				LastForwardedPort = port;
 				Debug.Log($"Port {port.ToString()} forwarded successfully!");
 			}

--- a/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorUtils.cs
+++ b/LiteNetLib4Mirror/Assets/Mirror/Runtime/Transport/LiteNetLib4Mirror/LiteNetLib4MirrorUtils.cs
@@ -19,13 +19,13 @@ namespace Mirror.LiteNetLib4Mirror
 	public static class LiteNetLib4MirrorUtils
 	{
 		internal static ushort LastForwardedPort;
-		public static string SharedKey { get; set; }
+		internal static readonly string ApplicationName;
 		public static bool UpnpFailed { get; private set; }
 		public static IPAddress ExternalIp { get; private set; }
 
 		static LiteNetLib4MirrorUtils()
 		{
-			SharedKey = Application.productName + Application.companyName;
+			ApplicationName = Application.productName;
 		}
 
 		public static string ToBase64(string text)
@@ -52,11 +52,11 @@ namespace Mirror.LiteNetLib4Mirror
 
 		public static NetDataWriter ReusePutDiscovery(NetDataWriter writer, string text, ref string lastText)
 		{
-			if (SharedKey + text != lastText)
+			if (LiteNetLib4MirrorDiscovery.DiscoveryKey + text != lastText)
 			{
-				lastText = SharedKey + text;
+				lastText = LiteNetLib4MirrorDiscovery.DiscoveryKey + text;
 				writer.Reset();
-				writer.Put(SharedKey);
+				writer.Put(LiteNetLib4MirrorDiscovery.DiscoveryKey);
 				writer.Put(ToBase64(text));
 			}
 
@@ -155,7 +155,7 @@ namespace Mirror.LiteNetLib4Mirror
 				}
 
 				ExternalIp = await device.GetExternalIPAsync();
-				await device.CreatePortMapAsync(new Mapping(networkProtocolType, IPAddress.None, port, port, 0, Application.productName)).ConfigureAwait(false);
+				await device.CreatePortMapAsync(new Mapping(networkProtocolType, IPAddress.None, port, port, 0, ApplicationName)).ConfigureAwait(false);
 				LastForwardedPort = port;
 				Debug.Log($"Port {port.ToString()} forwarded successfully!");
 			}


### PR DESCRIPTION
This PR renames `LiteNetLib4MirrorUtils.ApplicationName` to `LiteNetLib4MirrorUtils.SharedKey` and makes use of it everywhere discovery and connection requests are validated.

Users can override the default value of the key (`"Application.productName + Application.companyName"`) before initialising their network code, as follows:

```
LiteNetLib4MirrorUtils.SharedKey = "Custom shared key";
```

This removes the reliance on client and server apps to have the same product name to connect to one another, as discussed in #13, but leaves the default behaviour of the transport unchanged.